### PR TITLE
Allow token size to be configured and add end to end tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,11 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libboost-all-dev libpcre2-dev libcli11-dev catch2
+    - name: Build project
+      run: |
+        export DEFAULT_LIB_PATH=$(realpath --relative-to=$PWD /usr/lib/x86_64-linux-gnu)
+        export DEFAULT_INCLUDE_PATH=$(realpath --relative-to=$PWD /usr/include)
+        zig build -Doptimize=ReleaseFast
     - name: Run tests
       run: |
         export DEFAULT_LIB_PATH=$(realpath --relative-to=$PWD /usr/lib/x86_64-linux-gnu)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,6 @@ jobs:
         export DEFAULT_LIB_PATH=$(realpath --relative-to=$PWD /usr/lib/x86_64-linux-gnu)
         export DEFAULT_INCLUDE_PATH=$(realpath --relative-to=$PWD /usr/include)
         zig build test
+    - name: Run end to end tests
+      run: |
+        ./endtoend-test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ainotes
 .env
 GEMINI.md
 karpathy-models/
+tests/

--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ shakespeare.txt (train 2)
 
 ## TODO Notes and C++ related
 
-* TODO check performance of going back to vector instead of forward_list when training in each mode
-* TODO Warnings when specifying unused arguments. vocab size and encoder only matter for training
-* TODO Use zip/tail to simplify the tricky pair iterator logic and see if it impairs performance
-* TODO Add end to end test script
+* TODO :Performance: check performance of going back to vector instead of forward_list when training in each mode
+* TODO :Ergonomics: Warnings when specifying unused arguments. vocab size and encoder only matter for training
+* TODO :Fun: Use zip/tail to simplify the tricky pair iterator logic and see if it impairs performance
+* TODO :Verification: Add end to end test script comparing to Karpathy's train.py
 * DONE Add special token support for encoding and decoding
 * DONE Make build files more portable (Converting to zig build)
 * DONE replace tuple with pair

--- a/code/examples/minbpe-cc.cpp
+++ b/code/examples/minbpe-cc.cpp
@@ -59,7 +59,7 @@ expected<void,string> write_string_to_file(const path &path, const string &data)
 // it is based on the size of the vocabulary, but we could have a larger vocabulary.
 // Maybe a variable length encoding would be better.
 // I guess there is always variable length encoding
-expected<void,string> save_encoding(const path &path, const vector<int> encoded) {
+expected<void,string> save_encoding(const path &path, const vector<MinBpeCC::Tokenizer::Token> encoded) {
   std::ofstream file(path, std::ios::binary);
   if(!file) {
     std::error_code ec(errno, std::generic_category());
@@ -75,13 +75,13 @@ expected<void,string> save_encoding(const path &path, const vector<int> encoded)
   }
 }
 
-expected<vector<int>,string> load_encoding(const path &path) {
+expected<vector<MinBpeCC::Tokenizer::Token>,string> load_encoding(const path &path) {
     std::ifstream file(path, ios::binary);
     if (!file.is_open()) {
       std::error_code ec(errno, std::generic_category());
       return unexpected(ec.message());
     }
-    vector<int> data;
+    vector<MinBpeCC::Tokenizer::Token> data;
     uint32_t number;
     while(file.read(reinterpret_cast<char *>(&number), sizeof(uint32_t))) {
       data.push_back(number);

--- a/code/examples/minbpe-cc.cpp
+++ b/code/examples/minbpe-cc.cpp
@@ -55,10 +55,6 @@ expected<void,string> write_string_to_file(const path &path, const string &data)
   return {};
 }
 
-// Write out as 32 bit unsigned integers, this could be configurable. Requires thought,
-// it is based on the size of the vocabulary, but we could have a larger vocabulary.
-// Maybe a variable length encoding would be better.
-// I guess there is always variable length encoding
 expected<void,string> save_encoding(const path &path, const vector<MinBpeCC::Tokenizer::Token> encoded) {
   std::ofstream file(path, std::ios::binary);
   if(!file) {
@@ -66,10 +62,7 @@ expected<void,string> save_encoding(const path &path, const vector<MinBpeCC::Tok
     return unexpected(ec.message());
   } else {
     for (const auto& code : encoded) {
-      assert(code >= 0);
-      assert(code <= UINT32_MAX);
-      uint32_t c = static_cast<uint32_t>(code);
-      file.write(reinterpret_cast<const char *>(&c), sizeof(uint32_t));
+      file.write(reinterpret_cast<const char *>(&code), sizeof(MinBpeCC::Tokenizer::Token));
     }
     return {};
   }
@@ -82,8 +75,8 @@ expected<vector<MinBpeCC::Tokenizer::Token>,string> load_encoding(const path &pa
       return unexpected(ec.message());
     }
     vector<MinBpeCC::Tokenizer::Token> data;
-    uint32_t number;
-    while(file.read(reinterpret_cast<char *>(&number), sizeof(uint32_t))) {
+    MinBpeCC::Tokenizer::Token number;
+    while(file.read(reinterpret_cast<char *>(&number), sizeof(MinBpeCC::Tokenizer::Token))) {
       data.push_back(number);
     }
 

--- a/code/examples/train.cpp
+++ b/code/examples/train.cpp
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
   Tokenizer bt;
   bt.train(input, num_tokens, conflict_resolution, verbose);
 
-  Tokenizer rt = Tokenizer(Tokenizer::GPT4_SPLIT_PATTERN);
+  Tokenizer rt(Tokenizer::GPT4_SPLIT_PATTERN);
   rt.train(input, num_tokens, conflict_resolution, verbose);
 
   auto t2 = high_resolution_clock::now(); // Record end time

--- a/data/special1.txt
+++ b/data/special1.txt
@@ -1,5 +1,5 @@
-<|endoftext|> 100257
-<|fim_prefix|> 100258
-<|fim_middle|> 100259
-<|fim_suffix|> 100260
-<|endofprompt|> 100276
+<|endoftext|> 60000
+<|fim_prefix|> 60001
+<|fim_middle|> 60002
+<|fim_suffix|> 60003
+<|endofprompt|> 60004

--- a/endtoend-test.sh
+++ b/endtoend-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+mkdir -p tests
+
+# Run the basic encoding test
+./zig-out/bin/minbpe-cc --train --input data/shakespeare.txt --model-path tests/basic-model --vocab-size 512 --encoder basic --conflict-resolution lexical
+./zig-out/bin/minbpe-cc --encode --input data/sample.txt --model-path tests/basic-model --output tests/sample-encoded-basic
+./zig-out/bin/minbpe-cc --decode --input tests/sample-encoded-basic --model-path tests/basic-model --output tests/sample-decoded-basic
+diff tests/sample-decoded-basic data/sample.txt
+
+# Run the gpt4 regex with special tokens test
+./zig-out/bin/minbpe-cc --train --input data/taylorswift.txt --special-tokens-path ./data/special1.txt --model-path tests/gpt4-model --vocab-size 512 --encoder gpt4 --conflict-resolution first
+./zig-out/bin/minbpe-cc --encode --input data/specialtokensample.txt --model-path tests/gpt4-model --output tests/sample-encoded-gpt4
+./zig-out/bin/minbpe-cc --decode --input tests/sample-encoded-gpt4 --model-path tests/gpt4-model --output tests/sample-decoded-gpt4
+diff tests/sample-decoded-gpt4 data/specialtokensample.txt
+
+echo Tests succeeded


### PR DESCRIPTION
- **update docs**
- **parameterize the token numeric type**
- **add end to end testing**
- **fix that endoding saves ignoring the token size type**
